### PR TITLE
Fix boton editar

### DIFF
--- a/src/Components/Formulario/Formulario.module.css
+++ b/src/Components/Formulario/Formulario.module.css
@@ -11,7 +11,7 @@
   border-radius: 15px;
   box-shadow: none;
   width: 100%;
-  min-height: 100%;
+  height: fit-content;
   margin: 0;
   padding: 30px 40px;
   box-sizing: border-box;


### PR DESCRIPTION
Eliminacion de min-height: 100%;
En su lugar, agregamos height: fit-content; que ajusta la altura de un elemento automáticamente al tamaño necesario para mostrar su contenido (texto, imágenes), sin superar nunca los límites del contenedor padre.